### PR TITLE
Request context fitness for audit requirements

### DIFF
--- a/Request-Context.json
+++ b/Request-Context.json
@@ -55,9 +55,7 @@
         "userRole",
         "secondaryIdentifier",
         "purposeOfUse",
-        "userFullName",
-        "orgIdentifier",
-        "facilityIdentifier"
+        "userFullName"
     ],
     "definitions": {
         "purposeOfUseTypes": {

--- a/Request-Context.json
+++ b/Request-Context.json
@@ -34,6 +34,38 @@
             ]
         },
         "purposeOfUse": {
+            "type": "array",
+            "items": { "$ref": "purposeOfUseTypes" }
+        },
+        "userFullName": {
+            "type": "string",
+            "example": "Dr. Jane Doe"
+        },
+        "orgIdentifier": {
+            "type": "string",
+            "example": "O12345"
+        },
+        "facilityIdentifier": {
+            "type": "string",
+            "example": "F12345"
+        },
+        "endConsumerIpAddress": {
+            "type": "string",
+            "example": "1.2.3.4"
+        }
+    },
+    "required": [
+        "userIdentifier",
+        "userRole",
+        "secondaryIdentifier",
+        "purposeOfUse",
+        "userFullName",
+        "orgIdentifier",
+        "facilityIdentifier"
+    ],
+    "definitions": {
+        "purposeOfUseTypes": {
+        	"id": "purposeOfUseTypes",
             "type": "string",
             "enum": [
                 "PATRQT",
@@ -44,11 +76,5 @@
                 "SYSDEV"
             ]
         }
-    },
-    "required": [
-        "userIdentifier",
-        "userRole",
-        "secondaryIdentifier",
-        "purposeOfUse"
-    ]
+    }
 }

--- a/Request-Context.json
+++ b/Request-Context.json
@@ -48,10 +48,6 @@
         "facilityIdentifier": {
             "type": "string",
             "example": "F12345"
-        },
-        "endConsumerIpAddress": {
-            "type": "string",
-            "example": "1.2.3.4"
         }
     },
     "required": [


### PR DESCRIPTION
* Made purpose of use a list so multiple values can be accepted.
* Added user full name as a required field, as some users may not have a CPN
* Added organisation id as a required field, according to privacy requirements
* Added facility id as a required field, according to privacy requirements
* Added end consumer IP address as a field; while not technically marked as "required", this must be submitted if no exemption was granted during onboarding.