### PR TITLE
Screening integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+R4
+R5
+.vscode

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -183,7 +183,7 @@
     },
     "purposeOfUse": {
         "type": "array",
-        "items": { "$ref": "purposeOfUseTypes" }
+        "items": { "$ref": "#/definitions/purposeOfUseTypes" }
     },
     "userFullName": {
         "type": "string",

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -1,129 +1,168 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://github.com/tewhatuora/schemas/json-schema/Request-Context",
-    "description": "JSON schema for request context custom header schema for apps integrating with HNZ FHIR APIs",
-    "type": "object",
-    "properties": {
-      "userIdentifier": {
-        "type": "string",
-        "description": "The alphanumeric user id as known to the system they have signed into (which is consuming the FHIR API)",
-        "example": "janed55"
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://github.com/tewhatuora/schemas/json-schema/Request-Context",
+  "description": "JSON schema for request context custom header schema for apps integrating with HNZ FHIR APIs",
+  "type": "object",
+  "properties": {
+    "userIdentifier": {
+      "type": "string",
+      "description": "The alphanumeric user id as known to the system they have signed into (which is consuming the FHIR API)",
+      "example": "janed55"
+    },
+    "userRole": {
+      "type": "string",
+      "enum": [
+          "PAT",
+          "PROV"
+      ]
+    },
+    "hpiPractitioner": {
+      "type": "object",
+      "description": "The user's health practitioner HPI identification details",
+      "properties": {
+        "cpnNumber": {
+          "type": "string",
+          "description": "The Common Person Number or CPN (also known as HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
+          "example": "90ZZLP"
+        },
+        "registrationAuthorityNumber": {
+          "type": "object",
+          "description": "The registration number issued to a practitioner as an HPI reference",
+          "properties": {
+            "use": {
+              "type": "string",
+              "description": "Fixed to 'official'",
+              "example": "official"
+            },
+            "system": {
+              "type": "string",
+              "description": "Url that identifies the practitioner's registration authority/council from https://standards.digital.health.nz/ns/hpi-ra-identifier-code",
+              "example": "https://standards.digital.health.nz/ns/medical-council-id"
+            },
+            "value": {
+              "type": "string",
+              "description": "The number issued to the practitioner by their registration authority",
+              "example": "123456"
+            },
+            "assignerReference": {
+              "type": "string",
+              "description": "Reference to the HPI organization which assigned the number in the form GXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+              "example": "Organisation/G000000-E"
+            }
+          },
+          "required": ["system","value"]
+        }
       },
-      "userRole": {
+      "required": [ "cpnNumber", "registrationAuthorityNumber" ]        
+    },
+    "hpiFacility": {
+      "type": "object",
+      "description": "Describes the health facility where the practitioner is located when accessing screening information",
+      "properties": {
+        "use": {
+          "type": "string",
+          "description": "Fixed to 'official'",
+          "example": "official"
+        },
+        "system": {
+            "type": "string",
+            "description": "Fixed to the system Url for HPI Facility Ids",
+            "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
+        },
+        "value": {
+            "type": "string",
+            "description": "The Facility Id where the user is located in the form FXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+            "example": "FZZ958-K"
+        },
+        "name": {
+          "type": "string",
+          "description": "The Facility name",
+          "example": "Medical Centre Flat-Unit"
+        }
+      },
+      "required": [ "system", "value" ]
+    },
+    "hpiOrganisation": {
+      "type": "object",
+      "description": "Defines the health provider organisation the user is currently working in, as an HPI Organisation reference",
+      "properties": {
+        "use": {
+          "type": "string",
+          "description": "Fixed to 'official'",
+          "example": "official"
+        },
+        "system": {
+            "type": "string",
+            "description": "Fixed to the system Url for HPI Organisation Ids",
+            "example": "https://standards.digital.health.nz/ns/hpi-organisation-id"
+        },
+        "value": {
+            "type": "string",
+            "description": "The HPI Organisation Id in the form GXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+            "example": "GZZ956-B"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the health organisation",
+          "example": "Flat-Unit Address Org"
+        }
+      },
+      "required": ["system","value"]
+    },
+    "secondaryIdentifier": {
+      "type": "object",
+      "properties": {
+          "use": {
+              "type": "string"
+          },
+          "system": {
+              "type": "string"
+          },
+          "value": {
+              "type": "string"
+          }
+      },
+      "required": [
+          "use",
+          "system",
+          "value"
+      ]
+    },
+    "purposeOfUse": {
+        "type": "array",
+        "items": { "$ref": "purposeOfUseTypes" }
+    },
+    "userFullName": {
+        "type": "string",
+        "example": "Dr. Jane Doe"
+    },
+    "orgIdentifier": {
+      "type": "string",
+        "example": "O12345"
+    },
+    "facilityIdentifier": {
+        "type": "string",
+        "example": "F12345"
+    }
+  },
+  "required": [
+      "userIdentifier",
+      "purposeOfUse",
+      "userFullName"
+  ],
+  "definitions": {
+    "purposeOfUseTypes": {
+      "$id": "purposeOfUseTypes",
         "type": "string",
         "enum": [
-            "PAT",
-            "PROV"
+            "PATRQT",
+            "POPHLTH",
+            "TREAT",
+            "ETREAT",
+            "PUBHLTH",
+            "SCREENING",
+            "SYSDEV"
         ]
-      },
-      "hpiPractitioner": {
-        "type": "object",
-        "description": "The user's HPI health practitioner identification",
-        "properties": {
-          "cpnNumber": {
-            "type": "string",
-            "description": "The HPI Common Person Number (aka HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
-            "example": "90ZZLP"
-          },
-          "registrationAuthorityNumber": {
-            "type": "string",
-            "description": "The number issued to the practitioner by their registration authority",
-            "example": "123456"
-          },
-          "registrationAuthority": {
-            "type": "object",
-            "description": "Details of the registration authority aka registration council",
-            "properties": {
-              "raUrl": {
-                "type": "string",
-                "description": "The system Url for the practitioner's registration authority/council",
-                "example": "https://standards.digital.health.nz/ns/medical-council-id"
-              }
-            }
-          }
-        },
-        "required": [ "cpnNUmber", "registrationAuthorityNumber", "registrationAuthority" ]        
-      },
-      "hpiFacility": {
-        "type": "object",
-        "description": "Describes the health facility where the practitioner is located when accessing screening information",
-        "properties": {
-            "system": {
-                "type": "string",
-                "description": "The system Url for HPI Facility Ids",
-                "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
-            },
-            "value": {
-                "type": "string",
-                "description": "The Facility Id where the user is located in the form FXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
-                "example": "FZZ958-K"
-            },
-            "name": {
-              "type": "string",
-              "description": "The Facility name",
-              "example": "Medical Centre Flat-Unit"
-          }
-        },
-        "required": [
-            "system",
-            "value",
-            "name"
-        ]
-      },
-      "secondaryIdentifier": {
-        "type": "object",
-        "properties": {
-            "use": {
-                "type": "string"
-            },
-            "system": {
-                "type": "string"
-            },
-            "value": {
-                "type": "string"
-            }
-        },
-        "required": [
-            "use",
-            "system",
-            "value"
-        ]
-      },
-      "purposeOfUse": {
-          "type": "array",
-          "items": { "$ref": "purposeOfUseTypes" }
-      },
-      "userFullName": {
-          "type": "string",
-          "example": "Dr. Jane Doe"
-      },
-      "orgIdentifier": {
-        "type": "string",
-          "example": "O12345"
-      },
-      "facilityIdentifier": {
-          "type": "string",
-          "example": "F12345"
-      }
-    },
-    "required": [
-        "userIdentifier",
-        "purposeOfUse",
-        "userFullName"
-    ],
-    "definitions": {
-        "purposeOfUseTypes": {
-        	"$id": "purposeOfUseTypes",
-            "type": "string",
-            "enum": [
-                "PATRQT",
-                "POPHLTH",
-                "TREAT",
-                "ETREAT",
-                "PUBHLTH",
-                "SCREENING",
-                "SYSDEV"
-            ]
-        }
     }
+  }
 }

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -1,43 +1,43 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://github.com/tewhatuora/schemas/json-schema/Screening-Request-Context",
-    "description": "JSON schema for request context custom header schema for apps integrating with HNZ / Te Whatu Ora Screening FHIR API",
+    "$id": "https://github.com/tewhatuora/schemas/json-schema/Request-Context",
+    "description": "JSON schema for request context custom header schema for apps integrating with HNZ FHIR APIs",
     "type": "object",
     "properties": {
-      "practitionerIdentifiers": {
+      "userIdentifier": {
+        "type": "string",
+        "description": "Identifies the user by their HPI Common Person Number (aka health practitioner index)",
+        "example": "90ZZLP"
+      },
+      "userRole": {
+        "type": "string",
+        "enum": [
+            "PAT",
+            "PROV"
+        ]
+      },
+      "practitionerRegistration": {
         "type": "object",
-        "description": "Identifies the practitioner using the application to access screening information",
+        "description": "The health practitioner's professional registration details",
         "properties": {
-          "cpnNumber": {
-              "type": "string",
-              "description": "The user's Common Person Number (also known as HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
-              "example": "90ZZLP"
-          },
           "registrationAuthorityNumber": {
+            "type": "string",
+            "description": "The number issued to the practitioner by their registration authority",
+            "example": "123456"
+          },
+          "registrationAuthority": {
             "type": "object",
-            "description": "Identifies the practitioner by their registration authority/council number",
+            "description": "Details of the registration authority aka registration council",
             "properties": {
-              "raSystem": {
+              "raUrl": {
                 "type": "string",
                 "description": "The system Url for the practitioner's registration authority/council",
                 "example": "https://standards.digital.health.nz/ns/medical-council-id"
-              },
-              "raNumber": {
-                  "type": "string",
-                  "description": "The number issued to the practitioner by their registration authority",
-                  "example": "123456"
               }
-            },
-            "required": [
-              "raSystem",
-              "raNumber"
-            ]
+            }
           }
         },
-        "required": [
-          "cpnNumber",
-          "registrationAuthorityNumber"
-        ]
+        "required": [ "registrationAuthorityNumber", "registrationAuthority" ]        
       },
       "hpiFacility": {
         "type": "object",
@@ -65,6 +65,25 @@
             "name"
         ]
       },
+      "secondaryIdentifier": {
+        "type": "object",
+        "properties": {
+            "use": {
+                "type": "string"
+            },
+            "system": {
+                "type": "string"
+            },
+            "value": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "use",
+            "system",
+            "value"
+        ]
+      },
       "purposeOfUse": {
           "type": "array",
           "items": { "$ref": "purposeOfUseTypes" }
@@ -72,12 +91,18 @@
       "userFullName": {
           "type": "string",
           "example": "Dr. Jane Doe"
+      },
+      "orgIdentifier": {
+        "type": "string",
+          "example": "O12345"
+      },
+      "facilityIdentifier": {
+          "type": "string",
+          "example": "F12345"
       }
     },
     "required": [
-        "practitionerIdentifiers",
-        "registrationAuthorityNumber",
-        "hpiFacility",
+        "userIdentifier",
         "purposeOfUse",
         "userFullName"
     ],

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -6,8 +6,8 @@
     "properties": {
       "userIdentifier": {
         "type": "string",
-        "description": "Identifies the user by their HPI Common Person Number (aka health practitioner index)",
-        "example": "90ZZLP"
+        "description": "The user Id as known to the system they have signed into (which is consuming the FHIR API)",
+        "example": "janedoe@bigmedicalcentre.co.nz"
       },
       "userRole": {
         "type": "string",
@@ -16,10 +16,15 @@
             "PROV"
         ]
       },
-      "practitionerRegistration": {
+      "hpiPractitioner": {
         "type": "object",
-        "description": "The health practitioner's professional registration details",
+        "description": "The user's HPI health practitioner identification",
         "properties": {
+          "cpnNumber": {
+            "type": "string",
+            "description": "The HPI Common Person Number (aka HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
+            "example": "90ZZLP"
+          },
           "registrationAuthorityNumber": {
             "type": "string",
             "description": "The number issued to the practitioner by their registration authority",
@@ -37,7 +42,7 @@
             }
           }
         },
-        "required": [ "registrationAuthorityNumber", "registrationAuthority" ]        
+        "required": [ "cpnNUmber", "registrationAuthorityNumber", "registrationAuthority" ]        
       },
       "hpiFacility": {
         "type": "object",

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://github.com/tewhatuora/schemas/json-schema/Request-Context",
   "description": "JSON schema for request context custom header schema for apps integrating with HNZ FHIR APIs",
+  "$comment": "This schema version 2.0 extends the original Request-Context.json public schema, adding new properties.  Properties from the original version remain but some have been deprecated due to the improved support for HPI references in this version",
   "type": "object",
   "properties": {
     "userIdentifier": {

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -6,8 +6,8 @@
     "properties": {
       "userIdentifier": {
         "type": "string",
-        "description": "The user Id as known to the system they have signed into (which is consuming the FHIR API)",
-        "example": "janedoe@bigmedicalcentre.co.nz"
+        "description": "The alphanumeric user id as known to the system they have signed into (which is consuming the FHIR API)",
+        "example": "janed55"
       },
       "userRole": {
         "type": "string",

--- a/json-schema/Request-Context-v2.json
+++ b/json-schema/Request-Context-v2.json
@@ -7,7 +7,7 @@
     "userIdentifier": {
       "type": "string",
       "description": "The alphanumeric user id as known to the system they have signed into (which is consuming the FHIR API)",
-      "example": "janed55"
+      "example": "LJRHODE"
     },
     "userRole": {
       "type": "string",
@@ -18,96 +18,148 @@
     },
     "hpiPractitioner": {
       "type": "object",
-      "description": "The user's health practitioner HPI identification details",
+      "description": "User health practitioner identification as an HPI FHIR reference",
       "properties": {
-        "cpnNumber": {
+        "type": {
           "type": "string",
-          "description": "The Common Person Number or CPN (also known as HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
-          "example": "90ZZLP"
+          "description": "Fixed to refer to FHIR Practitioner resource type",
+          "example": "Practitioner",
+          "pattern": "^Practitioner$"
         },
-        "registrationAuthorityNumber": {
+        "identifier": {
           "type": "object",
-          "description": "The registration number issued to a practitioner as an HPI reference",
+          "description": "These attributes constitute a FHIR Identifier for an HPI Practitioner resource",
           "properties": {
             "use": {
               "type": "string",
-              "description": "Fixed to 'official'",
-              "example": "official"
+              "description": "Fixed to official",
+              "const": "official"
             },
             "system": {
               "type": "string",
-              "description": "Url that identifies the practitioner's registration authority/council from https://standards.digital.health.nz/ns/hpi-ra-identifier-code",
-              "example": "https://standards.digital.health.nz/ns/medical-council-id"
+              "description": "Url that identifies a HPI Practitioner resource",
+              "const": "https://standards.digital.health.nz/ns/hpi-person-id"
             },
             "value": {
               "type": "string",
-              "description": "The number issued to the practitioner by their registration authority",
-              "example": "123456"
-            },
-            "assignerReference": {
-              "type": "string",
-              "description": "Reference to the HPI organization which assigned the number in the form GXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
-              "example": "Organisation/G000000-E"
+              "description": "The practitioner's Common Person Number or CPN as defined by the HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
+              "pattern": "^[0-9]{2}[A-Z0-9]{4}$",
+              "example": "91ZABY"
             }
           },
-          "required": ["system","value"]
+          "required": [ "use", "system", "value"]
+        },
+        "display": {
+          "type": "string",
+          "description": "The full name of the practitioner", 
+          "example": "Lyndi Jane Rhode"
         }
       },
-      "required": [ "cpnNumber", "registrationAuthorityNumber" ]        
+      "required": ["type","identifier","display"]
+    },          
+    "registrationAuthorityNumber": {
+      "type": "object",
+      "description": "These three attributes constitute a FHIR Identifier defining the registration number issued to a practitioner by their RA",
+      "properties": {
+        "use": {
+          "type": "string",
+          "description": "Fixed to official",
+          "const": "official"
+        },
+        "system": {
+          "type": "string",
+          "description": "Url identifying the practitioner's registration authority/council from https://standards.digital.health.nz/ns/hpi-ra-identifier-code",
+          "example": "https://standards.digital.health.nz/ns/medical-council-id"
+        },
+        "value": {
+          "type": "string",
+          "description": "Number issued to the practitioner by their registration authority",
+          "example": "123456"
+        }
+      },
+      "required": ["use","system","value"]
     },
     "hpiFacility": {
       "type": "object",
-      "description": "Describes the health facility where the practitioner is located when accessing screening information",
+      "description": "Identifies the health facility where the practitioner is located, as an HPI Facility (Location) FHIR Reference",
       "properties": {
-        "use": {
+        "type": {
           "type": "string",
-          "description": "Fixed to 'official'",
-          "example": "official"
+          "description": "Fixed to refer to a FHIR Location resource type",
+          "example": "Location",
+          "pattern": "^Location$"
         },
-        "system": {
-            "type": "string",
-            "description": "Fixed to the system Url for HPI Facility Ids",
-            "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
+        "identifier": {
+          "type": "object",
+          "description": "These three attributes constitute a FHIR Identifier for an HPI Facility (Location) resource",
+          "properties": {
+            "use": {
+              "type": "string",
+              "description": "Fixed to official",
+              "const": "official"
+            },
+            "system": {
+              "type": "string",
+              "description": "Url that identifies HPI Facility resource type",
+              "const": "https://standards.digital.health.nz/ns/hpi-facility-id"
+            },
+            "value": {
+              "type": "string",
+              "description": "HPI Facility Id in the form FXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+              "pattern": "^F[A-Z0-9]{2}[0-9]{3}-[A-Z]{1}$",
+              "example": "FZZ958-K"
+            }
+          },
+          "required": [ "use", "system", "value"]
         },
-        "value": {
-            "type": "string",
-            "description": "The Facility Id where the user is located in the form FXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
-            "example": "FZZ958-K"
-        },
-        "name": {
+        "display": {
           "type": "string",
-          "description": "The Facility name",
+          "description": "The display name of the health facility", 
           "example": "Medical Centre Flat-Unit"
         }
       },
-      "required": [ "system", "value" ]
+      "required": ["type","identifier","display"]
     },
     "hpiOrganisation": {
       "type": "object",
-      "description": "Defines the health provider organisation the user is currently working in, as an HPI Organisation reference",
+      "description": "Defines the health provider the user is currently working in, as an HPI Organisation FHIR Reference",
       "properties": {
-        "use": {
+        "type": {
           "type": "string",
-          "description": "Fixed to 'official'",
-          "example": "official"
+          "description": "Fixed to refer to FHIR Organization resources",
+          "example": "Organization",
+          "pattern": "^Organization$"
         },
-        "system": {
-            "type": "string",
-            "description": "Fixed to the system Url for HPI Organisation Ids",
-            "example": "https://standards.digital.health.nz/ns/hpi-organisation-id"
+        "identifier": {
+          "type": "object",
+          "description": "These three attributes constitute a FHIR Identifier for an HPI Organisation resource",
+          "properties": {
+            "use": {
+              "type": "string",
+              "description": "Fixed to official",
+              "const": "official"
+            },
+            "system": {
+              "type": "string",
+              "description": "Url that identifies a HPI Organisation resource type",
+              "const": "https://standards.digital.health.nz/ns/hpi-organisation-id"
+            },
+            "value": {
+              "type": "string",
+              "description": "HPI Organisation Id in the form GXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+              "pattern": "^G[A-Z0-9]{2}[0-9]{3}-[A-Z]{1}$",
+              "example": "GZZ956-B"
+            }
+          },
+          "required": [ "use", "system", "value"]
         },
-        "value": {
-            "type": "string",
-            "description": "The HPI Organisation Id in the form GXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
-            "example": "GZZ956-B"
-        },
-        "name": {
+        "display": {
           "type": "string",
-          "description": "Name of the health organisation",
+          "description": "The display name of the organisation", 
           "example": "Flat-Unit Address Org"
         }
       },
-      "required": ["system","value"]
+      "required": ["type","identifier","display"]
     },
     "secondaryIdentifier": {
       "type": "object",
@@ -138,11 +190,13 @@
     },
     "orgIdentifier": {
       "type": "string",
-        "example": "O12345"
+      "example": "O12345",
+      "deprecated": true
     },
-    "facilityIdentifier": {
-        "type": "string",
-        "example": "F12345"
+  "facilityIdentifier": {
+      "type": "string",
+      "example": "F12345",
+      "deprecated": true
     }
   },
   "required": [
@@ -164,5 +218,49 @@
             "SYSDEV"
         ]
     }
-  }
+  },
+  "examples": [
+    {
+      "userIdentifier": "aute laborum",
+      "userRole": "PAT",
+      "registrationAuthorityNumber": {
+        "use": "official",
+        "system": "Lorem",
+        "value": "quis nulla sunt"
+      },
+      "hpiFacility": {
+        "type": "Location",
+        "identifier": {
+          "use": "official",
+          "system": "https://standards.digital.health.nz/ns/hpi-facility-id",
+          "value": "FRZ738-R"
+        },
+        "display": "cillum tempor quis"
+      },
+      "hpiOrganisation": {
+        "type": "Organization",
+        "identifier": {
+          "use": "official",
+          "system": "https://standards.digital.health.nz/ns/hpi-organisation-id",
+          "value": "GO0518-X"
+        },
+        "display": "Excepteur do consequat reprehenderit magna"
+      },
+      "secondaryIdentifier": {
+        "use": "adipisicing sit dolor nostrud",
+        "system": "adipisicing laborum",
+        "value": "commodo"
+      },
+      "purposeOfUse": [
+        "SYSDEV",
+        "PATRQT",
+        "ETREAT",
+        "SYSDEV",
+        "PUBHLTH"
+      ],
+      "userFullName": "amet esse ipsum ullamco",
+      "orgIdentifier": "veniam deserunt",
+      "facilityIdentifier": "qui proident non irure"
+    }
+  ]
 }

--- a/json-schema/Screening-Request-Context.json
+++ b/json-schema/Screening-Request-Context.json
@@ -103,7 +103,6 @@
         "userRole",
         "registrationAuthorityIdentifier",
         "hpiFacilityIdentifier",
-        "facilityName",
         "purposeOfUse",
         "userFullName"
     ],

--- a/json-schema/Screening-Request-Context.json
+++ b/json-schema/Screening-Request-Context.json
@@ -1,114 +1,89 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "HNZ | Te Whatu Ora request context header schema for screening application integration",
+    "$id": "https://github.com/tewhatuora/schemas/json-schema/Screening-Request-Context",
+    "description": "JSON schema for request context custom header schema for apps integrating with HNZ / Te Whatu Ora Screening FHIR API",
     "type": "object",
     "properties": {
-        "userIdentifier": {
-            "type": "string",
-            "example": "90ZZLP"
-        },
-        "userRole": {
-            "type": "string",
-            "enum": [
-                "PAT",
-                "PROV"
-            ]
-        },
-        "secondaryIdentifier": {
-            "type": "object",
-            "properties": {
-                "use": {
-                    "type": "string"
-                },
-                "system": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "use",
-                "system",
-                "value"
-            ]
-        },
-        "hpiFacilityIdentifier": {
-          "type": "object",
-          "properties": {
-              "use": {
-                "type": "string",
-                "example": "official"
-              },
-              "system": {
-                  "type": "string",
-                  "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
-              },
-              "value": {
-                  "type": "string",
-                  "example": "FZZ958-K"
-              }
+      "practitionerIdentifiers": {
+        "type": "object",
+        "description": "Identifies the practitioner using the application to access screening information",
+        "properties": {
+          "cpnNumber": {
+              "type": "string",
+              "description": "The user's Common Person Number (also known as HPI Practitioner Index) in the form NNXXXX where N is numeric and X is Alphabetic",
+              "example": "90ZZLP"
           },
-          "required": [
-              "use",
-              "system",
-              "value"
-          ]
-        },
-        "facilityName": {
-          "type": "string",
-          "example": "Medical Centre Flat-Unit"
-        },
-        "registrationAuthorityIdentifier": {
-          "type": "object",
-          "properties": {
-              "use": {
-                  "type": "string",
-                  "example": "official"
-              },  
-              "system": {
-                  "type": "string",
-                  "example": "https://standards.digital.health.nz/ns/medical-council-id"
+          "registrationAuthorityNumber": {
+            "type": "object",
+            "description": "Identifies the practitioner by their registration authority/council number",
+            "properties": {
+              "raSystem": {
+                "type": "string",
+                "description": "The system Url for the practitioner's registration authority/council",
+                "example": "https://standards.digital.health.nz/ns/medical-council-id"
               },
-              "value": {
+              "raNumber": {
                   "type": "string",
+                  "description": "The number issued to the practitioner by their registration authority",
                   "example": "123456"
               }
-          },
-          "required": [
-              "use",
-              "system",
-              "value"
-          ]
+            },
+            "required": [
+              "raSystem",
+              "raNumber"
+            ]
+          }
         },
-        "purposeOfUse": {
-            "type": "array",
-            "items": { "$ref": "purposeOfUseTypes" }
+        "required": [
+          "cpnNumber",
+          "registrationAuthorityNumber"
+        ]
+      },
+      "hpiFacility": {
+        "type": "object",
+        "description": "Describes the health facility where the practitioner is located when accessing screening information",
+        "properties": {
+            "system": {
+                "type": "string",
+                "description": "The system Url for HPI Facility Ids",
+                "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
+            },
+            "value": {
+                "type": "string",
+                "description": "The Facility Id where the user is located in the form FXXNNN-C where X is alphanumeric, N is numeric and C is a check character",
+                "example": "FZZ958-K"
+            },
+            "name": {
+              "type": "string",
+              "description": "The Facility name",
+              "example": "Medical Centre Flat-Unit"
+          }
         },
-        "userFullName": {
-            "type": "string",
-            "example": "Dr. Jane Doe"
-        },
-        "orgIdentifier": {
-            "type": "string",
-            "example": "O12345"
-        },
-        "facilityIdentifier": {
-            "type": "string",
-            "example": "F12345"
-        }
+        "required": [
+            "system",
+            "value",
+            "name"
+        ]
+      },
+      "purposeOfUse": {
+          "type": "array",
+          "items": { "$ref": "purposeOfUseTypes" }
+      },
+      "userFullName": {
+          "type": "string",
+          "example": "Dr. Jane Doe"
+      }
     },
     "required": [
-        "userIdentifier",
-        "userRole",
-        "registrationAuthorityIdentifier",
-        "hpiFacilityIdentifier",
+        "practitionerIdentifiers",
+        "registrationAuthorityNumber",
+        "hpiFacility",
         "purposeOfUse",
         "userFullName"
     ],
     "definitions": {
         "purposeOfUseTypes": {
-        	"id": "purposeOfUseTypes",
+        	"$id": "purposeOfUseTypes",
             "type": "string",
             "enum": [
                 "PATRQT",

--- a/json-schema/Screening-Request-Context.json
+++ b/json-schema/Screening-Request-Context.json
@@ -1,0 +1,125 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "HNZ | Te Whatu Ora request context header schema for screening application integration",
+    "type": "object",
+    "properties": {
+        "userIdentifier": {
+            "type": "string",
+            "example": "90ZZLP"
+        },
+        "userRole": {
+            "type": "string",
+            "enum": [
+                "PAT",
+                "PROV"
+            ]
+        },
+        "secondaryIdentifier": {
+            "type": "object",
+            "properties": {
+                "use": {
+                    "type": "string"
+                },
+                "system": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "use",
+                "system",
+                "value"
+            ]
+        },
+        "hpiFacilityIdentifier": {
+          "type": "object",
+          "properties": {
+              "use": {
+                "type": "string",
+                "example": "official"
+              },
+              "system": {
+                  "type": "string",
+                  "example": "https://standards.digital.health.nz/ns/hpi-facility-id"
+              },
+              "value": {
+                  "type": "string",
+                  "example": "FZZ958-K"
+              }
+          },
+          "required": [
+              "use",
+              "system",
+              "value"
+          ]
+        },
+        "facilityName": {
+          "type": "string",
+          "example": "Medical Centre Flat-Unit"
+        },
+        "registrationAuthorityIdentifier": {
+          "type": "object",
+          "properties": {
+              "use": {
+                  "type": "string",
+                  "example": "official"
+              },  
+              "system": {
+                  "type": "string",
+                  "example": "https://standards.digital.health.nz/ns/medical-council-id"
+              },
+              "value": {
+                  "type": "string",
+                  "example": "123456"
+              }
+          },
+          "required": [
+              "use",
+              "system",
+              "value"
+          ]
+        },
+        "purposeOfUse": {
+            "type": "array",
+            "items": { "$ref": "purposeOfUseTypes" }
+        },
+        "userFullName": {
+            "type": "string",
+            "example": "Dr. Jane Doe"
+        },
+        "orgIdentifier": {
+            "type": "string",
+            "example": "O12345"
+        },
+        "facilityIdentifier": {
+            "type": "string",
+            "example": "F12345"
+        }
+    },
+    "required": [
+        "userIdentifier",
+        "userRole",
+        "registrationCouncilNumber",
+        "hpiFacilityIdentifier",
+        "facilityName",
+        "purposeOfUse",
+        "userFullName"
+    ],
+    "definitions": {
+        "purposeOfUseTypes": {
+        	"id": "purposeOfUseTypes",
+            "type": "string",
+            "enum": [
+                "PATRQT",
+                "POPHLTH",
+                "TREAT",
+                "ETREAT",
+                "PUBHLTH",
+                "SCREENING",
+                "SYSDEV"
+            ]
+        }
+    }
+}

--- a/json-schema/Screening-Request-Context.json
+++ b/json-schema/Screening-Request-Context.json
@@ -101,7 +101,7 @@
     "required": [
         "userIdentifier",
         "userRole",
-        "registrationCouncilNumber",
+        "registrationAuthorityIdentifier",
         "hpiFacilityIdentifier",
         "facilityName",
         "purposeOfUse",

--- a/openapi-definitions/Request-Context.json
+++ b/openapi-definitions/Request-Context.json
@@ -1,5 +1,5 @@
 {
   "type": "string",
   "format": "base64",
-  "description": "A base64 encoded JSON object that represents the request context for the current request. See the applicable schema in https://github.com/tewhatuora/schemas/ for definitions of context attributes"
+  "description": "A base64 encoded JSON object that represents the request context for the current request. See the schema https://github.com/tewhatuora/schemas/Request-Context-v2 for context properties"
 }

--- a/openapi-definitions/Request-Context.json
+++ b/openapi-definitions/Request-Context.json
@@ -1,5 +1,5 @@
 {
   "type": "string",
   "format": "base64",
-  "description": "A base64 encoded JSON object that represents the request context for the current request. See https://github.com/tewhatuora/schemas/blob/main/json-schema/Request-Context.json for schema"
+  "description": "A base64 encoded JSON object that represents the request context for the current request. See the applicable schema in https://github.com/tewhatuora/schemas/ for definitions of context attributes"
 }

--- a/openapi-definitions/Request-Context.json
+++ b/openapi-definitions/Request-Context.json
@@ -1,5 +1,5 @@
 {
   "type": "string",
   "format": "base64",
-  "description": "A base64 encoded JSON object that represents the request context for the current request. See the schema https://github.com/tewhatuora/schemas/Request-Context-v2 for context properties"
+  "description": "A base64 encoded JSON object that represents the request context for the current request. See the schema https://github.com/tewhatuora/schemas/Request-Context-v2.json for context properties"
 }


### PR DESCRIPTION
Extends the existing request context to allow better capture of
- practitioner RA registration
- HPI facility

Adds a new purpose of use type "SCREENING"

Note that this schema REDUCES the requirements for the base data but all v1 _request-context_ properties supplied by existing clients remain compatible in the revised schema